### PR TITLE
add removeDueDate to Card Model

### DIFF
--- a/lib/Trello/Model/Card.php
+++ b/lib/Trello/Model/Card.php
@@ -127,7 +127,7 @@ class Card extends AbstractObject implements CardInterface
     /**
      * {@inheritdoc}
      */
-    public function setDueDate(\DateTime $due)
+    public function setDueDate(\DateTime $due = null)
     {
         $this->data['due'] = $due;
 
@@ -146,16 +146,6 @@ class Card extends AbstractObject implements CardInterface
         return new \DateTime($this->data['due']);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function removeDueDate()
-    {
-        $this->data['due'] = null;
-
-        return $this;
-    }
-    
     /**
      * {@inheritdoc}
      */

--- a/lib/Trello/Model/Card.php
+++ b/lib/Trello/Model/Card.php
@@ -149,6 +149,16 @@ class Card extends AbstractObject implements CardInterface
     /**
      * {@inheritdoc}
      */
+    public function removeDueDate()
+    {
+        $this->data['due'] = null;
+
+        return $this;
+    }
+    
+    /**
+     * {@inheritdoc}
+     */
     public function setEmail($email)
     {
         $this->data['email'] = $email;

--- a/lib/Trello/Model/CardInterface.php
+++ b/lib/Trello/Model/CardInterface.php
@@ -94,7 +94,7 @@ interface CardInterface extends ObjectInterface
      *
      * @return CardInterface
      */
-    public function setDueDate(\DateTime $due);
+    public function setDueDate(\DateTime $due = null);
 
     /**
      * Get due date
@@ -103,13 +103,6 @@ interface CardInterface extends ObjectInterface
      */
     public function getDueDate();
 
-    /**
-     * Remove the due date
-     * 
-     * @return CardInterface
-     */
-    public function removeDueDate();
-    
     /**
      * Set email
      *

--- a/lib/Trello/Model/CardInterface.php
+++ b/lib/Trello/Model/CardInterface.php
@@ -104,6 +104,13 @@ interface CardInterface extends ObjectInterface
     public function getDueDate();
 
     /**
+     * Remove the due date
+     * 
+     * @return CardInterface
+     */
+    public function removeDueDate();
+    
+    /**
      * Set email
      *
      * @param string $email


### PR DESCRIPTION
Hi,

i wanted to add the removeDueDate method to the Card Model because setDueDate does not allow resetting the DueDate because of the missing default value.
From the CardInterface `public function setDueDate(\DateTime $due);`

I was thinking about changing it to `public function setDueDate(\DateTime $due = null);`

But rather found having a dedicated removeDueDate method more suitable.
I know that `Trello\Api\Card`would allow me resetting the due date already.
`public function setDueDate($id, \DateTime $date = null)`

But please see the example below where i would need it.

```php
<?php
     $manager = new Manager($trelloClient);

     ...

     $list = $manager->getList($listId);
     $cards = $list->getCards();
     foreach ($cards as $card) {
          $card->removeDueDate();
          $card->save();
     }
     ...
```