### PR TITLE
added endpoint to get boards for organization

### DIFF
--- a/docs/Api/Organization.md
+++ b/docs/Api/Organization.md
@@ -6,3 +6,7 @@ Trello Organization API
 $api->organizations()->show(string $id, array $params)
 ```
 
+### Boards API
+```php
+$api->members()->boards()
+```

--- a/docs/Api/Organization/Boards.md
+++ b/docs/Api/Organization/Boards.md
@@ -1,0 +1,7 @@
+Trello Member Boards API
+======================
+
+### Get boads related to a given organization
+```php
+$api->organization()->boards()->all(string $id, array $params)
+```

--- a/lib/Trello/Api/Organization.php
+++ b/lib/Trello/Api/Organization.php
@@ -53,4 +53,14 @@ class Organization extends AbstractApi
     {
         return $this->get($this->getPath().'/'.rawurlencode($id), $params);
     }
+
+    /**
+     * Boards API
+     *
+     * @return Organization\Boards
+     */
+    public function boards()
+    {
+        return new Organization\Boards($this->client);
+    }
 }

--- a/lib/Trello/Api/Organization/Boards.php
+++ b/lib/Trello/Api/Organization/Boards.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Trello\Api\Organization;
+
+use Trello\Api\AbstractApi;
+use Trello\Api\Board;
+use Trello\Api\Member\Board\Backgrounds;
+use Trello\Api\Member\Board\Stars;
+use Trello\Exception\InvalidArgumentException;
+
+/**
+ * Trello Member Boards API
+ * @link https://trello.com/docs/api/member
+ *
+ * Fully implemented.
+ */
+class Boards extends AbstractApi
+{
+    protected $path = 'organization/#id#/boards';
+
+    /**
+     * Get boads related to a given member
+     * @link https://trello.com/docs/api/member/#get-1-members-idmember-or-username-boards
+     *
+     * @param string $id     the organization's id or username
+     * @param array  $params optional parameters
+     *
+     * @return array
+     */
+    public function all($id, array $params = array())
+    {
+        return $this->get($this->getPath($id), $params);
+    }
+
+    /**
+     * Filter boards related to a given member
+     * @link https://trello.com/docs/api/member/#get-1-members-idmember-or-username-boards-filter
+     *
+     * @param string       $id     the board's id
+     * @param string|array $filter array of / one of 'all', none', 'open', 'closed', 'all'
+     *
+     * @return array
+     */
+    public function filter($id, $filter = 'all')
+    {
+        $allowed = array('all', 'members', 'organization', 'public', 'open', 'closed', 'pinned', 'unpinned', 'starred');
+        $filters = $this->validateAllowedParameters($allowed, $filter, 'filter');
+
+        return $this->get($this->getPath($id).'/'.implode(',', $filters));
+    }
+}

--- a/test/Trello/Tests/Unit/Api/Organization/BoardsTest.php
+++ b/test/Trello/Tests/Unit/Api/Organization/BoardsTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Trello\Tests\Unit\Api\Organization;
+
+use Trello\Tests\Unit\Api\TestCase;
+
+/**
+ * @group unit
+ */
+class BoardsTest extends TestCase
+{
+    protected $apiPath = 'organization/#id#/boards';
+
+    /**
+     * @test
+     */
+    public function shouldGetAllBoards()
+    {
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with($this->getPath())
+            ->will($this->returnValue($this->fakeId));
+
+        $this->assertEquals($this->fakeId, $api->all($this->fakeParentId));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldFilterBoardsWithDefaultFilter()
+    {
+        $defaultFilter = 'all';
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with($this->getPath().'/'.$defaultFilter)
+            ->will($this->returnValue($defaultFilter));
+
+        $this->assertEquals($defaultFilter, $api->filter($this->fakeParentId));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldFilterBoardsWithStringArgument()
+    {
+        $filter = 'open';
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with($this->getPath().'/open')
+            ->will($this->returnValue($filter));
+
+        $this->assertEquals($filter, $api->filter($this->fakeParentId, $filter));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldFilterBoardsWithArrayArgument()
+    {
+        $filter = array('open','closed');
+
+        $api = $this->getApiMock();
+        $api->expects($this->once())
+            ->method('get')
+            ->with($this->getPath().'/open,closed')
+            ->will($this->returnValue($filter));
+
+        $this->assertEquals($filter, $api->filter($this->fakeParentId, $filter));
+    }
+
+    protected function getApiClass()
+    {
+        return 'Trello\Api\Organization\Boards';
+    }
+}


### PR DESCRIPTION
I added endpoint to be able to get list of boards of organization [link to api](https://developers.trello.com/advanced-reference/organization#get-1-organizations-idorg-or-name-boards)

this commit is including endpoint, extended documentation and tests