### PR TITLE
fix command order

### DIFF
--- a/lib/Trello/Api/Card/Actions.php
+++ b/lib/Trello/Api/Card/Actions.php
@@ -53,6 +53,6 @@ class Actions extends AbstractApi
      */
     public function removeComment($id, $commentId)
     {
-        return $this->delete($this->getPath($id).'/comments/'.rawurlencode($commentId));
+        return $this->delete($this->getPath($id).'/'.rawurlencode($commentId).'/comments');
     }
 }


### PR DESCRIPTION
https://trello.com/docs/api/card/#delete-1-cards-card-id-or-shortlink-actions-idaction-comments

Expects `commentId` before `/comments` not after.