### PR TITLE
Trello API convention for POST/PUT card members is idMembers instead of members.

### DIFF
--- a/lib/Trello/Api/Card/Members.php
+++ b/lib/Trello/Api/Card/Members.php
@@ -46,7 +46,8 @@ class Members extends AbstractApi
 
         $members = implode(',', $members);
 
-        return $this->put($this->getPath($id), array('value' => $members));
+        $path = str_replace('/members', '/idMembers', $this->getPath($id));
+        return $this->put($path, array('value' => $members));
     }
 
     /**
@@ -60,7 +61,8 @@ class Members extends AbstractApi
      */
     public function add($id, $memberId)
     {
-        return $this->post($this->getPath($id), array('value' => $memberId));
+        $path = str_replace('/members', '/idMembers', $this->getPath($id));
+        return $this->post($path, array('value' => $memberId));
     }
 
     /**


### PR DESCRIPTION
For `set` and `add` methods, use `cards/#id#/idMembers` instead of `cards/#id#/members`, in `POST /1/cards/[card id or shortlink]/idMembers` link
