### PR TITLE
Overwrite `Member::getId()` to return the true ID

### DIFF
--- a/lib/Trello/Model/Member.php
+++ b/lib/Trello/Model/Member.php
@@ -16,6 +16,14 @@ class Member extends AbstractObject implements MemberInterface
     );
 
     /**
+     * @return string
+     */
+    public function getId()
+    {
+        return $this->data['id'];
+    }
+    
+    /**
      * {@inheritdoc}
      */
     public function setAvatarHash($avatarHash)


### PR DESCRIPTION
Previously, if instantiated with a username, `getId()` would return a username.
This commit fixes that behaviour.