### PR TITLE
Fix state check for checklist items

### DIFF
--- a/lib/Trello/Model/Checklist.php
+++ b/lib/Trello/Model/Checklist.php
@@ -242,7 +242,7 @@ class Checklist extends AbstractObject implements ChecklistInterface
     protected function postRefresh()
     {
         foreach ($this->data['checkItems'] as $key => $item) {
-            $this->data['checkItems'][$key]['state'] = in_array($item['state'], array(true, 'complete', 'true'));
+            $this->data['checkItems'][$key]['state'] = in_array($item['state'], array(true, 'complete', 'true'), true);
         }
     }
 


### PR DESCRIPTION
Fixes #21. Without this, adding items to an existing checklist results in all existing items being checked, regardless of their previous state.